### PR TITLE
fix/make-sure-startsWith-can-be-used

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepublish": "npm test && npm run lint && npm run build"
   },
   "dependencies": {
+    "babel-polyfill": "^6.9.0",
     "bluebird": "^3.3.5",
     "fs-extra": "^0.30.0",
     "ramda": "^0.21.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import "babel-polyfill";
+import 'babel-polyfill';
 import FileSystemCache from './cache';
 export default (options) => new FileSystemCache(options);

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
+import "babel-polyfill";
 import FileSystemCache from './cache';
 export default (options) => new FileSystemCache(options);


### PR DESCRIPTION
To make sure `String.prototype.startsWith` method from ECMAScript 6 can be directly used in the npm package and github. 

Please replace `import "babel-polyfill";` by `require("babel-polyfill");` in the npm package. 
