### PR TITLE
Fix unreturned promise warnings

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -175,14 +175,14 @@ export default class FileSystemCache {
           const remove = (index) => {
             const path = paths[index];
             if (path) {
-              f.removeFileP(path)
-              .then(() => remove(index + 1)) // <== RECURSION.
-              .catch(err => reject(err));
+              return f.removeFileP(path)
+                .then(() => remove(index + 1)) // <== RECURSION.
+                .catch(err => reject(err));
             } else {
-              resolve(); // All files have been removed.
+              return Promise.resolve(); // All files have been removed.
             }
           };
-          remove(0);
+          return remove(0);
         })
         .catch(err => reject(err));
     });


### PR DESCRIPTION
When executing the clear() method I recieve warnings that state

```
at new Promise (/foo/bar/node_modules/file-system-cache/node_modules/bluebird/js/release/promise.js:77:14)
(node:15947) Warning: a promise was created in a handler at foo/bar/node_modules/file-system-cache/src/cache.js:179:27 but was not returned from it, see http://goo.gl/rRqMUw
```

This commit fixes the issue since the promises are now properly chained and returned from the wrapping method `clear()`.