### PR TITLE
Add commonjs reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ const cache = Cache({
 });
 ```
 
+> Reference `default` for CommonJS, e.g: `const Cache = require('file-system-cache').default
+`
+
 The optional `ns` ("namespace") allows for multiple groupings of files to reside within the one cache folder.  When you have multiple caches with different namespaces you can re-use the same keys and they will not collide.
 
 


### PR DESCRIPTION
For those importing modules using commonjs in some cases will need to reference the `default` property when requiring the module.

```js 
const Cache = require('file-system-cache').default
const cache = Cache()
```
Not referencing `default` will throw  `cache is not a function` 
