### PR TITLE
update ramda dependency to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Security
 
 
+## [1.1.0] - 2021-04-04
+#### Changed
+- bumped the ramda depedency version to resolve [ReDos](https://security.snyk.io/vuln/SNYK-JS-RAMDA-1582370)
+
 
 ## [1.0.3] - 2016-01-26
 #### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-system-cache",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "A super-fast, promise-based cache that reads and writes to the file-system.",
   "main": "./lib/index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "fs-extra": "^0.30.0",
-    "ramda": "^0.28.0"
+    "ramda": "^0.27.2"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "fs-extra": "^0.30.0",
-    "ramda": "^0.21.0"
+    "ramda": "^0.28.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
The `ramda` dependency should be updated #9

The `ramda@0.21.0` has a vulnerability
https://security.snyk.io/vuln/SNYK-JS-RAMDA-1582370

#Solution:
Update `ramda` to use the version that resolves this vulnerability.

Please let me know if any further explanation/information would be needed.