### PR TITLE
fs-extra types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Deprecated
 #### Removed
 #### Fixed
+- "@types/fs-extra" types as devDependency causing upstream issues
 #### Security
 
 

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@types/ramda": "0.29.3",
+    "@types/fs-extra": "11.0.1",
     "fs-extra": "11.1.1",
     "ramda": "0.29.0"
   },
   "devDependencies": {
     "@types/chai": "4.3.5",
     "@types/expect": "24.3.0",
-    "@types/fs-extra": "11.0.1",
     "@types/mocha": "10.0.1",
     "chai": "4.3.7",
     "mocha": "10.2.0",


### PR DESCRIPTION
Similar to issue https://github.com/philcockfield/file-system-cache/issues/32

When `skipLibCheck` is false, typescript raises an error as `@types/fs-extra` is missing.

```
$ tsc --noEmit && webpack
node_modules/file-system-cache/lib/common/libs.d.ts:2:16 - error TS7016: Could not find a declaration file for module 'fs-extra'. '/frontend/node_modules/fs-extra/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/fs-extra` if it exists or add a new declaration (.d.ts) file containing `declare module 'fs-extra';`

2 import fs from 'fs-extra';
                 ~~~~~~~~~~


Found 1 error in node_modules/file-system-cache/lib/common/libs.d.ts:2

```