### PR TITLE
Fix missing comma in example init block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ import Cache from "file-system-cache";
 const cache = Cache({
   basePath: "./.cache", // (optional) Path where cache files are stored (default).
   ns: "my-namespace",   // (optional) A grouping namespace for items.
-  hash: "sha1"          // (optional) A hashing algorithm used within the cache key.
-  ttl: 60               // (optional) A time-to-live (in secs) on how long an item remains cached.
+  hash: "sha1",         // (optional) A hashing algorithm used within the cache key.
+  ttl: 60,              // (optional) A time-to-live (in secs) on how long an item remains cached.
 });
 ```
 


### PR DESCRIPTION
I also added a trailing comma to avoid this in the future, but if we don't like trailing commas here that's fine.