### PR TITLE
ESM + CJS builds on the 3.x version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-system-cache",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.1",
   "description": "A super-fast, promise-based cache that reads and writes to the file-system.",
   "keywords": [
     "cache",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-system-cache",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.7",
   "description": "A super-fast, promise-based cache that reads and writes to the file-system.",
   "keywords": [
     "cache",
@@ -19,21 +19,22 @@
     "url": "https://github.com/philcockfield"
   },
   "type": "module",
+  "main": "./lib/index.cjs",
+  "module": "./lib/index.js",
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
-      "default": "./lib/index.js"
+      "require": "./lib/index.cjs"
     },
     "./package.json": "./package.json"
   },
-  "main": "./lib/index.js",
   "files": [
     "README.md",
     "lib/**"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --clean --minify --dts --format esm --out-dir lib --treeshake",
+    "build": "tsup",
     "format": "prettier ./src --write",
     "gen:hashtype": "tsx ./script.ts/generate-hashtype.ts",
     "prepublish": "npm test && npm run build",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  minify: true,
+  outDir: 'lib',
+  treeshake: true,
+});


### PR DESCRIPTION
FIX for #49 , #52, #53

---

Solution idea provided by [conorfuller](https://github.com/conorfuller) within #52 

> This is a Node 20/Next 14 based application and we are using a commonjs environment and am unable to switch easily to use ESM. Is it possible to add default exports to the package.json for increased module support? As has been done here for `next/auth` https://github.com/nextauthjs/next-auth/pull/11224/commits/b1a81024071e688cb4168c81047ac97febb91691

↑ 
NB: does not work.

Solution approach:
- alternative CJS + ESM typescript builder → [npm] pipeline
- [dnt](https://deno.com/blog/publish-esm-cjs-module-dnt)

---

```
npm i file-system-cache@3.0.0-alpha.<latest>
```


### Test sequence (CJS):


```js
// filename: index.js
const fsc = require('file-system-cache');
```

```
node index.js
```


### Test sequence (ESM):

```js
// filename: index.js
import fsc from "file-system-cache";

const cache = fsc();
console.log(cache);

```

```
node index.js
```

